### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,10 @@ setuptools.setup(
             "capstone-windows==3.0.4",
         ],
         ":sys_platform == 'darwin'": [
-            "capstone==3.0.5rc2",
+            "capstone==3.0.5",
         ],
         ":sys_platform == 'linux2'": [
-            "capstone==3.0.5rc2",
+            "capstone==3.0.5",
         ],
     },
 )


### PR DESCRIPTION
Update capstone from 3.0.5rc2 to 3.0.5.

Some pypi mirror does not sync pre-release package, so now install capstone==3.0.5rc2 would failed. capstone 3.0.5 released in 2018 and can work perfect with cuckoo.